### PR TITLE
Adiciona componente Spinner

### DIFF
--- a/projects/sx_lib_front/src/lib/components/index.ts
+++ b/projects/sx_lib_front/src/lib/components/index.ts
@@ -31,3 +31,4 @@ export * from './toolbar';
 export * from './view-list';
 export * from './breadcrumbs';
 export * from './header-buttons';
+export * from './spinner';

--- a/projects/sx_lib_front/src/lib/components/spinner/index.ts
+++ b/projects/sx_lib_front/src/lib/components/spinner/index.ts
@@ -1,0 +1,1 @@
+export * from './spinner.component';

--- a/projects/sx_lib_front/src/lib/components/spinner/spinner.component.html
+++ b/projects/sx_lib_front/src/lib/components/spinner/spinner.component.html
@@ -1,0 +1,4 @@
+<div class="spinner" role="status"></div>
+@if(mensagem){
+<span>{{ mensagem }}</span>
+}

--- a/projects/sx_lib_front/src/lib/components/spinner/spinner.component.scss
+++ b/projects/sx_lib_front/src/lib/components/spinner/spinner.component.scss
@@ -1,0 +1,24 @@
+@use "../../design/colors/ds-colors.scss" as *;
+@use "../../design/mixins/flex.mixin.scss" as *;
+
+$spinner-diameter: 3rem;
+
+:host {
+  @include flex(column, center, center);
+}
+
+.spinner {
+  display: inline-block;
+  width: $spinner-diameter;
+  height: $spinner-diameter;
+  border: 0.4rem solid $color-support-200;
+  border-top-color: $color-primary-500;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/projects/sx_lib_front/src/lib/components/spinner/spinner.component.ts
+++ b/projects/sx_lib_front/src/lib/components/spinner/spinner.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   selector: 'sx-spinner',

--- a/projects/sx_lib_front/src/lib/components/spinner/spinner.component.ts
+++ b/projects/sx_lib_front/src/lib/components/spinner/spinner.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, Input, input } from '@angular/core';
+
+@Component({
+  selector: 'sx-spinner',
+  imports: [],
+  templateUrl: './spinner.component.html',
+  styleUrl: './spinner.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SpinnerComponent {
+  @Input() mensagem = '';
+}

--- a/projects/sx_lib_front/src/stories/spinner.stories.ts
+++ b/projects/sx_lib_front/src/stories/spinner.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { SpinnerComponent } from 'sx_lib_front';
+
+const meta: Meta<SpinnerComponent> = {
+  title: 'Spinner',
+  component: SpinnerComponent,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<SpinnerComponent>;
+
+export const Primary: Story = {
+  name: 'Spinner',
+  argTypes: {
+    mensagem: {
+      description: 'Mensagem do spinner',
+      control: 'text',
+      type: 'string',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+      },
+    },
+  },
+  args: {
+    mensagem: 'Carregando...',
+  },
+};


### PR DESCRIPTION
O intuito é dividir a responsabilidade do componente Loader, deixar o Loader apenas para exibições globais e o Spinner para exibições específicas no sistema.